### PR TITLE
Added option to set X-Sumo-Category header which overrides the "Sourc…

### DIFF
--- a/src/Serilog.Sinks.SumoLogic/LoggerConfigurationSumoLogicExtensions.cs
+++ b/src/Serilog.Sinks.SumoLogic/LoggerConfigurationSumoLogicExtensions.cs
@@ -17,6 +17,7 @@ namespace Serilog.Sinks.SumoLogic
         /// <param name="loggerConfiguration">The logger configuration</param>
         /// <param name="endpointUrl">Sumo Logic endpoint URL to send logs to</param>
         /// <param name="sourceName">Sumo Logic source name</param>
+        /// <param name="sourceCategory">Sumo Logic source category</param>
         /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
         /// <param name="batchSizeLimit">The maximum number of events to post in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>
@@ -28,6 +29,7 @@ namespace Serilog.Sinks.SumoLogic
             this LoggerSinkConfiguration loggerConfiguration,
             string endpointUrl,
             string sourceName = SumoLogicSink.DefaultSourceName,
+            string sourceCategory = SumoLogicSink.DefaultSourceCategory,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             int batchSizeLimit = SumoLogicSink.DefaultBatchSizeLimit,
             TimeSpan? period = null,
@@ -46,6 +48,7 @@ namespace Serilog.Sinks.SumoLogic
             var sink = new SumoLogicSink(
                 endpointUrl,
                 sourceName,
+                sourceCategory,
                 formatter,
                 batchSizeLimit,
                 defaultPeriod);

--- a/src/Serilog.Sinks.SumoLogic/Sinks/SumoLogicSink.cs
+++ b/src/Serilog.Sinks.SumoLogic/Sinks/SumoLogicSink.cs
@@ -18,10 +18,12 @@ namespace Serilog.Sinks.SumoLogic.Sinks
     {
         private readonly string _endpointUrl;
         private readonly string _sourceName;
+        private readonly string _sourceCategory;
         private readonly ITextFormatter _textFormatter;
         private readonly HttpClient _httpClient;
 
         private const string SumoNameRequestHeader = "X-Sumo-Name";
+        private const string SumoCategoryRequestHeader = "X-Sumo-Category";
 
         /// <summary>
         /// The default maximum number of events to include in a single batch.
@@ -32,6 +34,11 @@ namespace Serilog.Sinks.SumoLogic.Sinks
         /// Sumo Logic default source name
         /// </summary>
         public const string DefaultSourceName = "Serilog";
+
+        /// <summary>
+        /// Sumo Logic default source category
+        /// </summary>
+        public const string DefaultSourceCategory = "";
 
         /// <summary>
         /// The default output template
@@ -48,18 +55,21 @@ namespace Serilog.Sinks.SumoLogic.Sinks
         /// </summary>
         /// <param name="endpointUrl">Sumo Logic endpoint URL to send logs to</param>
         /// <param name="sourceName">Sumo Logic source name</param>
+        /// <param name="sourceCategory">Sumo Logic category name</param>
         /// <param name="textFormatter">Supplies how logs should be formatted</param>
         /// <param name="batchSizeLimit">The maximum number of events to post in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>
         public SumoLogicSink(
             string endpointUrl,
             string sourceName,
+            string sourceCategory,
             ITextFormatter textFormatter,
-            int batchSizeLimit, 
+            int batchSizeLimit,
             TimeSpan period) : base(batchSizeLimit, period)
         {
             _endpointUrl = endpointUrl;
             _sourceName = sourceName;
+            _sourceCategory = sourceCategory;
             _textFormatter = textFormatter;
 
             _httpClient = new HttpClient();
@@ -80,7 +90,7 @@ namespace Serilog.Sinks.SumoLogic.Sinks
 
         protected string GetFormattedLog(LogEvent logEvent)
         {
-            if(logEvent == null)
+            if (logEvent == null)
                 throw new ArgumentNullException(nameof(logEvent));
 
             using (var stringWriter = new StringWriter())
@@ -95,6 +105,8 @@ namespace Serilog.Sinks.SumoLogic.Sinks
             var formattedLog = GetFormattedLog(logEvent);
             var content = new StringContent(formattedLog, Encoding.UTF8, "text/plain");
             content.Headers.Add(SumoNameRequestHeader, _sourceName);
+            if (_sourceCategory != DefaultSourceCategory)
+                content.Headers.Add(SumoCategoryRequestHeader, _sourceCategory);
 
             return content;
         }

--- a/src/Serilog.Sinks.SumoLogic/Sinks/SumoLogicSink.cs
+++ b/src/Serilog.Sinks.SumoLogic/Sinks/SumoLogicSink.cs
@@ -105,7 +105,7 @@ namespace Serilog.Sinks.SumoLogic.Sinks
             var formattedLog = GetFormattedLog(logEvent);
             var content = new StringContent(formattedLog, Encoding.UTF8, "text/plain");
             content.Headers.Add(SumoNameRequestHeader, _sourceName);
-            if (_sourceCategory != DefaultSourceCategory)
+            if (!string.IsNullOrWhiteSpace(_sourceCategory))
                 content.Headers.Add(SumoCategoryRequestHeader, _sourceCategory);
 
             return content;


### PR DESCRIPTION
Added option to set X-Sumo-Category header which overrides the "Source Category".
This is useful if you want to use a single HTTP-Source to ingest logs from multiple applications but still have separate source categories.
The X-Sumo-Category header will only be added if the sourceCategory parameter is set. This allows you to still use the HTTP-Source's default "Source Category" if you want.