### PR TITLE
Add timezone info to DefaultOutputTemplate's timestamp

### DIFF
--- a/src/Serilog.Sinks.SumoLogic/Sinks/SumoLogicSink.cs
+++ b/src/Serilog.Sinks.SumoLogic/Sinks/SumoLogicSink.cs
@@ -43,7 +43,7 @@ namespace Serilog.Sinks.SumoLogic.Sinks
         /// <summary>
         /// The default output template
         /// </summary>
-        public const string DefaultOutputTemplate = "{Timestamp:yyyy-MM-dd HH:mm:ss} [{Level}] {Message}{NewLine}{Exception}";
+        public const string DefaultOutputTemplate = "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level}] {Message}{NewLine}{Exception}";
 
         /// <summary>
         /// The default period.


### PR DESCRIPTION
Although there are multiple methods of getting SumoLogic to correctly parse the Timestamp included in the message, like specifying a [ custom format ](https://help.sumologic.com/Send_Data/Sources/04Reference_Information_for_Sources/Timestamps,_Time_Zones,_Time_Ranges,_and_Date_Formats#Timestamp_format) to parse when [configuring the source](https://help.sumologic.com/Send_Data/Sources/03Use_JSON_to_Configure_Sources#Common_parameters_for_all_Source_types), we can just include the timezone in the log message and it will eliminate incorrect parsing.